### PR TITLE
chore(ci): disable branch triggers for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ name: Build and Upload APK
 # Setup: Add bot as admin to channel, get channel ID (@channelname or -100XXXXXXXXX)
 on:
   push:
-    branches: [ master, 'release/*' ]
+    # branches: [ master, 'release/*' ]
     tags:
       - 'v*' # Trigger on version tags (e.g. v0.8.0)
 


### PR DESCRIPTION
- Comment out branches trigger (master, release/*)
- Keep only tag trigger (v*) for intentional releases
- Reduces unnecessary CI runs and ensures releases are deliberate